### PR TITLE
Add tool restrictions, model routing, and resume-based retry logic

### DIFF
--- a/agents/context-scribe.md
+++ b/agents/context-scribe.md
@@ -1,7 +1,9 @@
 ---
 name: context-scribe
 description: Agent for maintaining CONTEXT.md project tracking file. Use after completing tasks, when planning, or when decisions are made.
-model: inherit
+model: haiku
+tools: Read, Edit, Glob, Bash
+disallowedTools: Write, Task, WebSearch, WebFetch
 color: pink
 ---
 

--- a/agents/tech-learning-coach.md
+++ b/agents/tech-learning-coach.md
@@ -2,6 +2,8 @@
 name: tech-learning-coach
 description: Use this agent when you want to learn a new technology, framework, library, or programming concept through guided, step-by-step instruction. This agent excels at breaking down complex topics into manageable learning tasks, creating practical examples, and providing structured learning paths. Perfect for when you need a patient tutor who will work alongside you rather than doing everything for you.\n\nExamples:\n<example>\nContext: User wants to learn React hooks\nuser: "I want to learn how to use React hooks"\nassistant: "I'll use the tech-learning-coach agent to create a structured learning plan for React hooks"\n<commentary>\nSince the user wants to learn a new technology concept, use the Task tool to launch the tech-learning-coach agent to create a step-by-step learning plan.\n</commentary>\n</example>\n<example>\nContext: User is exploring a new API\nuser: "Help me understand how to work with the Stripe API"\nassistant: "Let me bring in the tech-learning-coach agent to guide us through learning the Stripe API step by step"\n<commentary>\nThe user needs guided learning for a new technology, so the tech-learning-coach agent is appropriate.\n</commentary>\n</example>
 model: inherit
+tools: Read, Grep, Glob, Bash, WebSearch, WebFetch
+disallowedTools: Write, Edit, Task
 color: blue
 ---
 

--- a/agents/the-architect.md
+++ b/agents/the-architect.md
@@ -2,6 +2,8 @@
 name: the-architect
 description: Use for architectural decisions with >1 month implementation time, affecting multiple systems/teams, or requiring detailed trade-off analysis. Examples: database selection, microservices migration, API design strategy, system-wide technology choices.
 model: inherit
+tools: Read, Grep, Glob, Bash, WebSearch, WebFetch, Task
+disallowedTools: Write, Edit
 color: purple
 examples:
   - context: User needs to decide on a database architecture for a new microservice

--- a/commands/sub_agents.md
+++ b/commands/sub_agents.md
@@ -83,8 +83,16 @@ For each sub-task, mark `PASS` or `FAIL` with concrete evidence (diffs, command 
 
 **If FAIL** (max 2 retries):
 1. Diagnose failure mode (wrong output / incomplete / errors / wrong approach).
-2. Re-spawn NEW sub-agent with: original task, prior output, failure diagnosis, correction instructions.
-3. Re-validate. After 2 failures: escalate to user with best-available path forward.
+2. **Resume** the existing sub-agent (do NOT spawn a new one) with:
+   - Failure diagnosis
+   - Specific correction instructions
+   - Any new context discovered during validation
+
+   Resuming preserves the sub-agent's full conversation history—prior tool calls, results, and reasoning—avoiding redundant context re-establishment and reducing token usage.
+3. Re-validate. After 2 failures: escalate to user with:
+   - Best-available partial result
+   - Specific blockers preventing completion
+   - Options and risks for user decision
 
 ### Phase 4: Integrate & Present
 


### PR DESCRIPTION
- Add tool/disallowedTools to all three custom agents for least-privilege access
- Change context-scribe to use haiku model (simple file updates don't need sonnet)
- Update sub_agents retry loop to resume existing agents instead of spawning new ones

https://claude.ai/code/session_013K3Rc1vBF9z5SfaRe6jHHc