### PR TITLE
Move rm commands from allow to ask permission list

### DIFF
--- a/settings.json
+++ b/settings.json
@@ -39,10 +39,6 @@
       "Bash(mv:*)",
       "Bash(touch:*)",
       "Bash(ln:*)",
-      "Bash(rm:*)",
-      "Bash(rm)",
-      "Bash(rm -rf:*)",
-      "Bash(rm -rf /)",
 
       "Bash(grep:*)",
       "Bash(egrep:*)",
@@ -133,6 +129,9 @@
       "Bash(gh:*)"
     ],
     "ask": [
+      "Bash(rm:*)",
+      "Bash(rm)",
+      "Bash(rm -rf:*)",
       "Bash"
     ]
   },


### PR DESCRIPTION
rm, rm -rf, and variants now require user confirmation before
executing. Dropped the redundant rm -rf / rule since rm -rf:*
already covers it.

https://claude.ai/code/session_01KGCGx6WjSCEHN3gqTELkQP