### PR TITLE
Simplify PR walkthrough — drop prescriptive structure, let the tool decide how to link

### DIFF
--- a/commands/pr_walkthrough.md
+++ b/commands/pr_walkthrough.md
@@ -1,6 +1,6 @@
 ---
 description: Walk through a PR bottom-up, explaining each change and how it connects
-version: "1.0"
+version: "1.1"
 ---
 
 # PR Walkthrough
@@ -32,90 +32,13 @@ git diff --stat $BASE..HEAD
 
 ## Build the Walkthrough
 
-### Step 1: Identify the Layers
+Start from the lowest-level changes (types, utilities, things nothing else depends on) and work up to the entry points (routes, handlers, CLI commands — where behavior is triggered).
 
-Scan the diff and sort changes into layers:
+For each change:
+- Say what was added or modified, and why it matters.
+- Show me where in the code.
+- Connect it to the other changes in this PR — what calls it, what it depends on.
 
-1. **Foundations** — new types, interfaces, constants, utility functions. Things that don't call other new code.
-2. **Core logic** — functions/methods that use the foundations. The actual work.
-3. **Wiring** — registration, DI bindings, middleware hookups, config changes that connect new code to existing code.
-4. **Entry points** — routes, handlers, CLI commands, event listeners, exports. Where the new behavior is triggered.
+After walking through the individual changes, trace 1-3 key paths end-to-end so I can see how the PR works as a whole.
 
-If a change doesn't fit neatly, place it where it first becomes relevant.
-
-### Step 2: Walk Each Layer, Bottom-Up
-
-For each layer (foundations → core logic → wiring → entry points), walk through the changes:
-
-- **What changed**: name the function/type/file and what was added or modified.
-- **Where**: `file:line` reference so the reader can jump directly to it.
-- **Why it exists**: one sentence on the purpose. Connect it to the broader goal of the PR.
-- **How it connects**: which other changes in this PR call it, depend on it, or are affected by it. Give `file:line` references for each connection.
-
-If commits are well-structured (each commit is a logical step), follow commit order within each layer. Otherwise, follow the dependency graph.
-
-### Step 3: Trace Key Paths
-
-After walking the layers, trace 1-3 key paths through the changes end-to-end:
-
-> "When [trigger] happens, it hits [entry point] at `file:line`, which calls [core function] at `file:line`, which uses [foundation] at `file:line`."
-
-Pick paths that best illustrate how the PR works as a whole.
-
-## File Link Format
-
-All file references use backtick `path/to/file.go:42` format. IDEs make these clickable automatically. For line ranges, use `path/to/file.go:10-25`.
-
-## Output Format
-
-```
-## PR Walkthrough: {branch}
-
-**Commits**: N commits on this branch
-**Files changed**: N files
-
----
-
-### Foundations
-
-#### `functionOrTypeName` — short description
-- **Where**: `path/to/file.go:42`
-- **What**: Describe concretely what was added or changed.
-- **Connects to**: `callerFunction` at `path/to/other.go:88`
-
-#### ...
-
----
-
-### Core Logic
-
-#### `functionName` — short description
-- **Where**: `path/to/file.go:100`
-- **What**: Describe what this does.
-- **Uses**: `foundationType` at `path/to/file.go:42`
-- **Called by**: `handlerName` at `path/to/handler.go:55`
-
-#### ...
-
----
-
-### Wiring
-
-#### ...
-
----
-
-### Entry Points
-
-#### ...
-
----
-
-### Key Paths
-
-1. **[Name the flow]**: `entryPoint` at `file:line` → `coreFunction` at `file:line` → `foundation` at `file:line`
-
-2. ...
-```
-
-Keep descriptions concrete. One to two sentences max per item. Let the `file:line` references do the heavy lifting — the reader will click through to the code in their IDE.
+Keep it concrete. A couple sentences per item max.


### PR DESCRIPTION
Removed the rigid layer taxonomy, exact output template, and file link format
spec. The prompt now just says: explain bottom-up, show me where in the code,
connect the changes, trace key paths. Leaves formatting to the tool.

https://claude.ai/code/session_01FhV1964zs9wmBJceH2FfTE