### PR TITLE
Fix context file naming convention in CLAUDE.md to match context_sync command

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,7 +5,7 @@
 - If a decision is hard to undo or changes user-facing behavior/scope, stop and ask.
 
 # Workflow
-- context/branchName-CONTEXT.md is the source of truth for project state (not applicable to main).
+- context/CONTEXT-{branch}.md is the source of truth for project state (not applicable to main).
 - Update it when plans, assumptions, or decisions change.
 - Before major work, check for project-specific agent rules (CLAUDE.md, .cursorrules, AGENTS.md, etc).
 


### PR DESCRIPTION
Changed from context/branchName-CONTEXT.md to context/CONTEXT-{branch}.md

https://claude.ai/code/session_019nerfACVa6c9Q3rEgw9iLj