### PR TITLE
Rename context/ directory to _context/ across all config files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,4 +25,3 @@ hooks/memory/query
 # Context files
 CONTEXT.md
 context.md
-_context/CONTEXT.json

--- a/.gitignore
+++ b/.gitignore
@@ -25,4 +25,4 @@ hooks/memory/query
 # Context files
 CONTEXT.md
 context.md
-context/CONTEXT.json
+_context/CONTEXT.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,7 +5,7 @@
 - If a decision is hard to undo or changes user-facing behavior/scope, stop and ask.
 
 # Workflow
-- context/CONTEXT-{branch}.md is the source of truth for project state (not applicable to main).
+- _context/CONTEXT-{branch}.md is the source of truth for project state (not applicable to main).
 - Update it when plans, assumptions, or decisions change.
 - Before major work, check for project-specific agent rules (CLAUDE.md, .cursorrules, AGENTS.md, etc).
 

--- a/agents/context-scribe.md
+++ b/agents/context-scribe.md
@@ -18,10 +18,10 @@ You are 'The Scribe,' a specialized agent that maintains `CONTEXT.md`. You are a
 ## File Location
 
 1. Get current branch: `git branch --show-current`
-2. Store in `context/` directory (create if needed)
+2. Store in `_context/` directory (create if needed)
 3. Naming:
-   - `main`/`master` branch → `context/CONTEXT.md`
-   - Other branches → `context/CONTEXT-{branch}.md`
+   - `main`/`master` branch → `_context/CONTEXT.md`
+   - Other branches → `_context/CONTEXT-{branch}.md`
 
 ## Template (for new files)
 

--- a/commands/branch_abstractions.md
+++ b/commands/branch_abstractions.md
@@ -47,8 +47,8 @@ Keep resolution fast — only search for detected abstractions, not full-repo sc
 
 ## Write Artifact
 
-- Store in `context/` directory (create if needed).
-- Filename: `context/{branch}-abstracts.md` where `{branch}` is the current git branch name.
+- Store in `_context/` directory (create if needed).
+- Filename: `_context/{branch}-abstracts.md` where `{branch}` is the current git branch name.
 
 ### Artifact Format
 
@@ -88,7 +88,7 @@ Limit notes to 3-6 bullets per abstraction. Be concrete, not speculative.
 After writing the artifact, print:
 
 ```
-Abstractions artifact: context/{branch}-abstracts.md
+Abstractions artifact: _context/{branch}-abstracts.md
 Abstractions found: N
 Top abstractions:
   - Name1

--- a/commands/context_sync.md
+++ b/commands/context_sync.md
@@ -9,9 +9,9 @@ Update or create the branch-specific context file to reflect current project sta
 ## File Naming
 
 - Get current branch: `git branch --show-current`
-- Store all context files in `context/` directory (create if needed)
-- If branch is `main` or `master`: use `context/CONTEXT.md`
-- Otherwise: use `context/CONTEXT-{branch}.md` (e.g., `context/CONTEXT-feature-auth.md`)
+- Store all context files in `_context/` directory (create if needed)
+- If branch is `main` or `master`: use `_context/CONTEXT.md`
+- Otherwise: use `_context/CONTEXT-{branch}.md` (e.g., `_context/CONTEXT-feature-auth.md`)
 
 ## Rules
 

--- a/commands/mermaid.md
+++ b/commands/mermaid.md
@@ -159,7 +159,7 @@ Explicitly state what the diagram covers:
 
 ### 6. Output
 
-**Output location**: `context/diagrams/<name>.<ext>`
+**Output location**: `_context/diagrams/<name>.<ext>`
 
 Where `<name>` is derived from the mode:
 - `--branch`: `branch-<branch-name>-dataflow`
@@ -298,7 +298,7 @@ When `--md` is specified, also generate a markdown file.
 
 ### HTML (default, `--branch` mode)
 
-`context/diagrams/branch-oauth-refresh-dataflow.html`:
+`_context/diagrams/branch-oauth-refresh-dataflow.html`:
 
 ```html
 <!DOCTYPE html>
@@ -375,7 +375,7 @@ flowchart LR
 
 ### Markdown (with `--md` flag, `--branch` mode)
 
-`context/diagrams/branch-oauth-refresh-dataflow.md`:
+`_context/diagrams/branch-oauth-refresh-dataflow.md`:
 
 ```markdown
 # Data Flow: OAuth Refresh (Branch Changes)
@@ -427,7 +427,7 @@ flowchart LR
 
 ### HTML (default, `--system` mode — unchanged from v1)
 
-`context/diagrams/system-auth-flow.html`:
+`_context/diagrams/system-auth-flow.html`:
 
 ```html
 <!DOCTYPE html>

--- a/commands/ticket_analysis.md
+++ b/commands/ticket_analysis.md
@@ -17,7 +17,7 @@ If `$ARGUMENTS` is empty, ask the user to provide the ticket title and/or descri
 
 Results are written to BOTH:
 1. Screen (displayed to user)
-2. `context/initial_review-{branch}.md` where `{branch}` comes from `git branch --show-current` (with `/` replaced by `-`)
+2. `_context/initial_review-{branch}.md` where `{branch}` comes from `git branch --show-current` (with `/` replaced by `-`)
 
 ## Workflow
 
@@ -102,12 +102,12 @@ Before implementing, review the codebase conventions (naming patterns, file stru
 **Output Actions**:
 
 1. Display the full report to the user
-2. Write the report to `context/initial_review-{branch}.md`:
+2. Write the report to `_context/initial_review-{branch}.md`:
    - Get branch: `git branch --show-current`
    - Replace `/` with `-` in branch name
-   - Create `context/` directory if it doesn't exist
-   - Write to `context/initial_review-{branch}.md`
-3. Confirm: "Report saved to `context/initial_review-{branch}.md`"
+   - Create `_context/` directory if it doesn't exist
+   - Write to `_context/initial_review-{branch}.md`
+3. Confirm: "Report saved to `_context/initial_review-{branch}.md`"
 
 ## Agents Used
 

--- a/hooks/load-context.sh
+++ b/hooks/load-context.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 branch=$(git branch --show-current 2>/dev/null | tr '/' '-')
 [ -z "$branch" ] && exit 0
-f="context/CONTEXT-${branch}.md"
+f="_context/CONTEXT-${branch}.md"
 [ -f "$f" ] && echo "[Context loaded: $f]" && cat "$f"
 exit 0


### PR DESCRIPTION
Underscore prefix keeps the directory visually separated and
conventionally marks it as generated/internal.

https://claude.ai/code/session_01RK3bTSdZLUV1Grrwy8GbwB