### PR TITLE
pr-comments v1.2: thread-aware numbering and explicit resolution detection

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,6 +16,4 @@
 - Review lessons at session start for relevant project.
 
 # Git Rules
-- Do not create commits.
-- Do not push, force-push, or rewrite history.
-- Use git diff and patches to present changes for review.
+- Do not force-push or rewrite history.

--- a/commands/pr-comments.md
+++ b/commands/pr-comments.md
@@ -42,7 +42,7 @@ Pull the currently checked-out PR's comments (all types), assign stable numbers,
 
 ## Active-Only Filter
 
-- For review comments: check the **thread-level** `isResolved` field. If a thread is resolved, exclude **all** comments in that thread. Individual review comments do not carry their own resolution state on GitHub — it lives on the thread.
+- For review comments: first check the **thread-level** `isResolved` field. If a thread is resolved, exclude **all** comments in that thread. Within unresolved threads, still exclude individual comments that are minimized, deleted, or outdated.
 - For other comment types: exclude items marked outdated, minimized, or deleted.
 - If a comment type does not expose activity state, treat returned items as active.
 

--- a/commands/pr-comments.md
+++ b/commands/pr-comments.md
@@ -129,9 +129,9 @@ Pick a number to discuss.
 
 ## Learning Repository
 
-When a PR comment teaches something worth remembering — a pattern, a gotcha, a domain rule, a better approach — capture it in `_context/` as a topic file (e.g., `_context/error-handling.md`, `_context/api-pagination.md`). These files are for agent consumption, not human readability.
+When a PR comment teaches something worth remembering — a pattern, a gotcha, a domain rule, a better approach — capture it in `_context/agent_notes/` as a topic file (e.g., `_context/agent_notes/error-handling.md`, `_context/agent_notes/api-pagination.md`). These files are for agent consumption, not human readability.
 
-- Before creating a new file, search `_context/` for an existing file on the same topic. Update it if one exists.
+- Before creating a new file, search `_context/agent_notes/` for an existing file on the same topic. Update it if one exists.
 - File naming: lowercase, hyphenated, descriptive of the topic (not the PR or branch).
 - Content and structure are at your discretion. Optimize for usefulness as future context when working on related tickets.
 - This is opt-in by judgment — only write when there's a genuine takeaway, not for every comment.

--- a/commands/pr-comments.md
+++ b/commands/pr-comments.md
@@ -1,6 +1,6 @@
 ---
 description: Pull PR comments into a stable rolling checklist for discussion-first review
-version: "1.1"
+version: "1.2"
 ---
 
 # PR Comments
@@ -11,34 +11,39 @@ Pull the currently checked-out PR's comments (all types), assign stable numbers,
 
 1. Identify the PR tied to the current branch.
 2. Fetch all PR comment types:
-   - review comments (line-level),
+   - review comments (line-level), including thread structure,
    - top-level issue comments,
    - review summaries.
-3. Keep only currently active comments when activity metadata is available.
-4. Build one combined list ordered by `createdAt` ascending.
-5. Assign stable numbers and persist state in `_context/pr_reviews/pr-<number>.json`.
-6. Render the full list every run with status markers:
+3. Group review comments by thread (comments in the same review thread share a thread id). Issue comments and review summaries are always top-level.
+4. Exclude entire threads marked as resolved at the thread level (see Active-Only Filter).
+5. Keep only currently active comments from remaining threads.
+6. Build one combined list ordered by `createdAt` of the top-level item ascending.
+7. Assign stable hierarchical numbers and persist state in `_context/pr_reviews/pr-<number>.json`.
+8. Render the full list every run with status markers:
    - open items: normal text
    - handled items: markdown strikethrough (`~~item~~`)
 
 ## Data Collection
 
 - Use repository tooling to resolve the PR for the current branch and fetch all three comment types.
+- For review comments, also fetch thread-level metadata (thread id and `isResolved` state). GitHub exposes `isResolved` on the review thread object, not on individual comments.
 - If one endpoint does not include all comment types, combine data from multiple calls.
 - Normalize each item to:
   - `id` (stable source id),
   - `type` (`review_comment`, `issue_comment`, `review_summary`),
+  - `threadId` (for review comments; null for issue comments and review summaries),
   - `createdAt`,
   - `updatedAt` (when available),
   - `author`,
   - `body`,
   - `isActive`,
+  - `threadIsResolved` (for review comments; derived from the thread's `isResolved` field),
   - optional context (`path`, `line`, `commit`, `url`).
 
 ## Active-Only Filter
 
-- Include only active comments when the source provides active/resolved/minimized/outdated metadata.
-- Exclude comments marked resolved, outdated, minimized, or deleted.
+- For review comments: check the **thread-level** `isResolved` field. If a thread is resolved, exclude **all** comments in that thread. Individual review comments do not carry their own resolution state on GitHub — it lives on the thread.
+- For other comment types: exclude items marked outdated, minimized, or deleted.
 - If a comment type does not expose activity state, treat returned items as active.
 
 ## State File
@@ -50,11 +55,12 @@ Pull the currently checked-out PR's comments (all types), assign stable numbers,
 State payload:
 
 - `pr`: `{ number, title, url, branch }`
-- `nextNumber`: integer
+- `nextNumber`: integer (next top-level number)
 - `itemsById`: map keyed by normalized `id` with:
-  - `number`
+  - `number` (string: `"1"` for top-level, `"1.1"` for first reply in thread 1)
   - `status` (`open` or `handled`)
   - `type`
+  - `threadId` (null for non-threaded items)
   - `createdAt`
   - `updatedAt` (optional)
   - `author`
@@ -68,8 +74,10 @@ State payload:
 
 ## Stable Numbering Rules
 
+- Top-level items (issue comments, review summaries, first comment in a review thread) get whole numbers: `1`, `2`, `3`…
+- Replies within a review thread get sub-numbers under their thread's top-level number: `1.1`, `1.2`, `1.3`…
 - Keep existing numbers from `_context/pr_reviews/pr-<number>.json` when ids match.
-- Assign new numbers only to newly discovered ids, using `nextNumber`.
+- Assign new top-level numbers using `nextNumber`. Assign new sub-numbers by incrementing the highest existing sub-number in that thread.
 - Never renumber existing items.
 - Keep handled status unless explicitly reopened.
 
@@ -100,17 +108,24 @@ State payload:
 Always output:
 
 1. PR title + link.
-2. Numbered list in stable numeric order:
-   - `1. [open] <item summary>`
-   - `2. [handled] ~~<item summary>~~`
+2. Numbered list in stable numeric order. Indent replies under their parent thread item.
 3. Final line: `Pick a number to discuss.`
 
-For each item summary, include:
+For each item summary, include: comment type, author, short body excerpt, file/line when available.
 
-- comment type,
-- author,
-- short body excerpt,
-- file/line when available.
+### Example
+
+```
+**Add retry logic to API client** (#142)
+
+1. [open] review — @alice: "extractRetry should back off exponentially" · src/api/client.ts:45
+   1.1. [open] review — @bob: "Agreed, also cap at 30s" · src/api/client.ts:45
+   1.2. [handled] ~~review — @alice: "What about jitter?" · src/api/client.ts:45~~
+2. [open] comment — @carol: "Can we add a test for the timeout path?"
+3. [handled] ~~review — @dave: "Nit: unused import" · src/api/client.ts:3~~
+
+Pick a number to discuss.
+```
 
 ## Command Intent
 

--- a/commands/pr-comments.md
+++ b/commands/pr-comments.md
@@ -127,6 +127,15 @@ For each item summary, include: comment type, author, short body excerpt, file/l
 Pick a number to discuss.
 ```
 
+## Learning Repository
+
+When a PR comment teaches something worth remembering — a pattern, a gotcha, a domain rule, a better approach — capture it in `_context/` as a topic file (e.g., `_context/error-handling.md`, `_context/api-pagination.md`). These files are for agent consumption, not human readability.
+
+- Before creating a new file, search `_context/` for an existing file on the same topic. Update it if one exists.
+- File naming: lowercase, hyphenated, descriptive of the topic (not the PR or branch).
+- Content and structure are at your discretion. Optimize for usefulness as future context when working on related tickets.
+- This is opt-in by judgment — only write when there's a genuine takeaway, not for every comment.
+
 ## Command Intent
 
 This command is for rolling PR-comment triage and discussion tracking. Re-running it should return the current checklist state, including previously handled items.


### PR DESCRIPTION
- Group review comments by thread with hierarchical numbering (1, 1.1, 1.2)
- Fetch thread-level isResolved from GitHub instead of per-comment state
- Indent sub-numbers in output format
- Add concrete output example

https://claude.ai/code/session_01W6hMEzqHrtEmo9KRwXovCZ