### PR TITLE
Add status and link metadata to context_sync command

### DIFF
--- a/commands/context_sync.md
+++ b/commands/context_sync.md
@@ -28,6 +28,8 @@ Update or create the branch-specific context file to reflect current project sta
    - **If exists**: Read current file, then selectively update (see step 4)
 3. Check `git status -sb` and `git diff --stat` for repo state
 4. Update these sections based on conversation and `$ARGUMENTS`:
+   - `Status` → first line in file, one of: `In Progress`, `In PR`, `Merged`
+   - `Links` → directly below `Status`; include Jira and GitHub PR links when available
    - `Last updated` → today's date
    - `Plan` → update if approach changes
    - `Tasks` → check off completed, add new ones
@@ -40,6 +42,12 @@ Update or create the branch-specific context file to reflect current project sta
 
 ```md
 # Project Context
+
+Status: In Progress
+
+## Links
+- Jira: *(link or N/A)*
+- GitHub PR: *(link or N/A)*
 
 Last updated: YYYY-MM-DD
 


### PR DESCRIPTION
### Motivation
- Ensure context files created/updated by the `context_sync` command always surface current state and references by requiring a top `Status` field and a `Links` block for Jira/GitHub PRs.

### Description
- Updated `commands/context_sync.md` to require a `Status` line as the first line (one of `In Progress`, `In PR`, `Merged`) and a `Links` section directly below it, and extended the new-context template in the same file to include default `Status` and `Links` entries.

### Testing
- Verified the change by inspecting `commands/context_sync.md` with `sed -n '1,240p' commands/context_sync.md` and `nl -ba commands/context_sync.md | sed -n '1,220p'`, and confirmed the new `Status` and `Links` lines are present.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ab3f05c3848323b4ee1d2d358a3eb2)