### PR TITLE
Add PR context reading and branch-scoped review output to code review skills

### DIFF
--- a/commands-archive/code_review.md
+++ b/commands-archive/code_review.md
@@ -94,4 +94,4 @@ If no issues found, say so and move on.
 
 ## Save Review
 
-**IMPORTANT**: You MUST save the review. Determine the current branch name with `git branch --show-current`. Run `mkdir -p _scratch/_reviews` then use the Write tool to write the full review output to `_scratch/_reviews/{branchname}-review.md` (replacing `{branchname}` with the actual branch name). Do not skip this step.
+**IMPORTANT**: You MUST save the review. Determine the current branch name with `git branch --show-current`, replacing any `/` characters with `-` to keep it a flat filename. Run `mkdir -p _scratch/_reviews` then use the Write tool to write the full review output to `_scratch/_reviews/{branchname}-review.md`. Do not skip this step.

--- a/commands-archive/code_review.md
+++ b/commands-archive/code_review.md
@@ -37,6 +37,10 @@ git diff --stat $BASE..HEAD
 
 **Important**: If a file appears in the diff that wasn't intentionally modified on this branch, ignore it - it's likely a rebase artifact.
 
+## PR Context
+
+If a PR exists for this branch, read the PR description first — it contains decisions and context that inform the review.
+
 ## Understand Context
 
 Before flagging issues, **read the surrounding code** in each changed file. The diff alone is not enough — you need context to judge correctness, types, contracts, and intent. Open the full file around changed lines.
@@ -90,4 +94,4 @@ If no issues found, say so and move on.
 
 ## Save Review
 
-**IMPORTANT**: You MUST save the review. Run `mkdir -p _scratch` then use the Write tool to write the full review output to `_scratch/REVIEW.md`. If `REVIEW.md` already exists, increment the suffix: `REVIEW_1.md`, `REVIEW_2.md`, etc. Do not skip this step.
+**IMPORTANT**: You MUST save the review. Determine the current branch name with `git branch --show-current`. Run `mkdir -p _scratch/_reviews` then use the Write tool to write the full review output to `_scratch/_reviews/{branchname}-review.md` (replacing `{branchname}` with the actual branch name). Do not skip this step.

--- a/commands-archive/code_review.md
+++ b/commands-archive/code_review.md
@@ -39,7 +39,7 @@ git diff --stat $BASE..HEAD
 
 ## PR Context
 
-If a PR exists for this branch, read the PR description first — it contains decisions and context that inform the review.
+If a PR exists for this branch, read the full PR (description, diff, and comments) first — it contains decisions and context that inform the review.
 
 ## Understand Context
 

--- a/commands-archive/code_review_parallel.md
+++ b/commands-archive/code_review_parallel.md
@@ -104,4 +104,4 @@ If no issues found, say so and move on.
 
 ## Save Review
 
-**IMPORTANT**: You MUST save the review. Determine the current branch name with `git branch --show-current`. Run `mkdir -p _scratch/_reviews` then use the Write tool to write the full review output to `_scratch/_reviews/{branchname}-review.md` (replacing `{branchname}` with the actual branch name). Do not skip this step.
+**IMPORTANT**: You MUST save the review. Determine the current branch name with `git branch --show-current`, replacing any `/` characters with `-` to keep it a flat filename. Run `mkdir -p _scratch/_reviews` then use the Write tool to write the full review output to `_scratch/_reviews/{branchname}-review.md`. Do not skip this step.

--- a/commands-archive/code_review_parallel.md
+++ b/commands-archive/code_review_parallel.md
@@ -39,7 +39,7 @@ git diff --stat $BASE..HEAD
 
 ## PR Context
 
-If a PR exists for this branch, read the PR description first — it contains decisions and context that inform the review.
+If a PR exists for this branch, read the full PR (description, diff, and comments) first — it contains decisions and context that inform the review.
 
 ## Parallel Review
 

--- a/commands-archive/code_review_parallel.md
+++ b/commands-archive/code_review_parallel.md
@@ -37,6 +37,10 @@ git diff --stat $BASE..HEAD
 
 **Important**: If a file appears in the diff that wasn't intentionally modified on this branch, ignore it - it's likely a rebase artifact.
 
+## PR Context
+
+If a PR exists for this branch, read the PR description first — it contains decisions and context that inform the review.
+
 ## Parallel Review
 
 Spawn 3 sub-agents in parallel. Each agent must **read the full changed files for context** — do not review the diff in isolation.
@@ -100,4 +104,4 @@ If no issues found, say so and move on.
 
 ## Save Review
 
-**IMPORTANT**: You MUST save the review. Run `mkdir -p _scratch` then use the Write tool to write the full review output to `_scratch/REVIEW.md`. If `REVIEW.md` already exists, increment the suffix: `REVIEW_1.md`, `REVIEW_2.md`, etc. Do not skip this step.
+**IMPORTANT**: You MUST save the review. Determine the current branch name with `git branch --show-current`. Run `mkdir -p _scratch/_reviews` then use the Write tool to write the full review output to `_scratch/_reviews/{branchname}-review.md` (replacing `{branchname}` with the actual branch name). Do not skip this step.

--- a/commands-archive/uncommitted_review.md
+++ b/commands-archive/uncommitted_review.md
@@ -31,6 +31,10 @@ git diff
 git status --short
 ```
 
+## PR Context
+
+If a PR exists for this branch, read the PR description first — it contains decisions and context that inform the review.
+
 ## Understand Context
 
 Before flagging issues, **read the surrounding code** in each changed file. The diff alone is not enough — you need context to judge correctness, types, contracts, and intent. Open the full file around changed lines.
@@ -84,4 +88,4 @@ If no issues found, say so and move on.
 
 ## Save Review
 
-**IMPORTANT**: You MUST save the review. Run `mkdir -p _scratch` then use the Write tool to write the full review output to `_scratch/REVIEW.md`. If `REVIEW.md` already exists, increment the suffix: `REVIEW_1.md`, `REVIEW_2.md`, etc. Do not skip this step.
+**IMPORTANT**: You MUST save the review. Determine the current branch name with `git branch --show-current`. Run `mkdir -p _scratch/_reviews` then use the Write tool to write the full review output to `_scratch/_reviews/{branchname}-review.md` (replacing `{branchname}` with the actual branch name). Do not skip this step.

--- a/commands-archive/uncommitted_review.md
+++ b/commands-archive/uncommitted_review.md
@@ -33,7 +33,7 @@ git status --short
 
 ## PR Context
 
-If a PR exists for this branch, read the PR description first — it contains decisions and context that inform the review.
+If a PR exists for this branch, read the full PR (description, diff, and comments) first — it contains decisions and context that inform the review.
 
 ## Understand Context
 

--- a/commands-archive/uncommitted_review.md
+++ b/commands-archive/uncommitted_review.md
@@ -88,4 +88,4 @@ If no issues found, say so and move on.
 
 ## Save Review
 
-**IMPORTANT**: You MUST save the review. Determine the current branch name with `git branch --show-current`. Run `mkdir -p _scratch/_reviews` then use the Write tool to write the full review output to `_scratch/_reviews/{branchname}-review.md` (replacing `{branchname}` with the actual branch name). Do not skip this step.
+**IMPORTANT**: You MUST save the review. Determine the current branch name with `git branch --show-current`, replacing any `/` characters with `-` to keep it a flat filename. Run `mkdir -p _scratch/_reviews` then use the Write tool to write the full review output to `_scratch/_reviews/{branchname}-review.md`. Do not skip this step.

--- a/commands-archive/uncommitted_review_parallel.md
+++ b/commands-archive/uncommitted_review_parallel.md
@@ -31,6 +31,10 @@ git diff
 git status --short
 ```
 
+## PR Context
+
+If a PR exists for this branch, read the PR description first — it contains decisions and context that inform the review.
+
 ## Parallel Review
 
 Spawn 3 sub-agents in parallel. Each agent must **read the full changed files for context** — do not review the diff in isolation.
@@ -94,4 +98,4 @@ If no issues found, say so and move on.
 
 ## Save Review
 
-**IMPORTANT**: You MUST save the review. Run `mkdir -p _scratch` then use the Write tool to write the full review output to `_scratch/REVIEW.md`. If `REVIEW.md` already exists, increment the suffix: `REVIEW_1.md`, `REVIEW_2.md`, etc. Do not skip this step.
+**IMPORTANT**: You MUST save the review. Determine the current branch name with `git branch --show-current`. Run `mkdir -p _scratch/_reviews` then use the Write tool to write the full review output to `_scratch/_reviews/{branchname}-review.md` (replacing `{branchname}` with the actual branch name). Do not skip this step.

--- a/commands-archive/uncommitted_review_parallel.md
+++ b/commands-archive/uncommitted_review_parallel.md
@@ -33,7 +33,7 @@ git status --short
 
 ## PR Context
 
-If a PR exists for this branch, read the PR description first — it contains decisions and context that inform the review.
+If a PR exists for this branch, read the full PR (description, diff, and comments) first — it contains decisions and context that inform the review.
 
 ## Parallel Review
 

--- a/commands-archive/uncommitted_review_parallel.md
+++ b/commands-archive/uncommitted_review_parallel.md
@@ -98,4 +98,4 @@ If no issues found, say so and move on.
 
 ## Save Review
 
-**IMPORTANT**: You MUST save the review. Determine the current branch name with `git branch --show-current`. Run `mkdir -p _scratch/_reviews` then use the Write tool to write the full review output to `_scratch/_reviews/{branchname}-review.md` (replacing `{branchname}` with the actual branch name). Do not skip this step.
+**IMPORTANT**: You MUST save the review. Determine the current branch name with `git branch --show-current`, replacing any `/` characters with `-` to keep it a flat filename. Run `mkdir -p _scratch/_reviews` then use the Write tool to write the full review output to `_scratch/_reviews/{branchname}-review.md`. Do not skip this step.


### PR DESCRIPTION
- Add "PR Context" section to all 4 review skills instructing reviewers to read the PR description for decisions/context
- Change review save path from _scratch/REVIEW.md to _scratch/_reviews/{branchname}-review.md

https://claude.ai/code/session_01Mfq8LkMZLhaM2WeRUozTs4